### PR TITLE
Fix lua syntax error

### DIFF
--- a/animations/scenarios/scenario_types_with_conditional_anims.lua
+++ b/animations/scenarios/scenario_types_with_conditional_anims.lua
@@ -4257,7 +4257,7 @@ local scenario_types_with_conditional_anims = {
       "CODE_WOLF_WARNING",
   },
 
-  ["FarmAnimal",
+  ["FarmAnimal"] = {
   },
 
   ["PROP_HitchingPost"] = {


### PR DESCRIPTION
Found a syntax error in the lua code in the `scenario_types_with_conditional_anims.lua`