### PR TITLE
Cleanup hud contexts (preset) list

### DIFF
--- a/graphics/HUD/hud_presets/hud_presets.lua
+++ b/graphics/HUD/hud_presets/hud_presets.lua
@@ -1,116 +1,117 @@
---	SET HUD PRESET:
---	Citizen.InvokeNative(0x4CC5F2FC1332577F ,GetHashKey("HUD_CTX_IN_FAST_TRAVEL_MENU"))   -- removes reticle, help, feed, award massages, etc.
+-- To enable a HUD context use:
+-- EnableHudContext(`HUD_CTX_IN_FAST_TRAVEL_MENU`)
 --
---	REMOVE HUD PRESET:
---	Citizen.InvokeNative(0x8BC7C1F929D07BF3 ,GetHashKey("HUD_CTX_IN_FAST_TRAVEL_MENU"))   -- revert reticle, help, feed, award massages, etc.
+-- To disable a HUD context use:
+-- DisableHudContext(`HUD_CTX_IN_FAST_TRAVEL_MENU`)
+--
+-- For more information visit https://github.com/femga/rdr3_discoveries/tree/master/databindings/hudcontexts
 
-local hud_presets = {
-	"HUD_CTX_AMBIENT_SPECTATOR_VIEW",						-- 0x7C2CFF26
-	"HUD_CTX_CHARACTER_CREATOR",							-- 0x6A16C358
-	"HUD_CTX_CODE_TOOLS",								-- 0x15E17C71
-	"HUD_CTX_CRAFTING_SEQUENCE",							-- 0xE3FEFB3D
-	"HUD_CTX_FADED_GAMEPLAY",							-- 0x6CD87394
-	"HUD_CTX_FEUD1_FISHING",							-- 0x54C5126F
-	"HUD_CTX_FIREFIGHT_CUTSCENE",							-- 0x675A0CCC
-	"HUD_CTX_FISHING",								-- 0xCCC6D67D
-	"HUD_CTX_GOLD_CURRENCY_CHANGE",							-- 0x7BD554C2
-	"HUD_CTX_HACK_RADAR_FORCE_HIDE",						-- 0x1C43984E
-	"HUD_CTX_HONOR_SHOW",								-- 0x074132EF
-	"HUD_CTX_IN_CAMP_WARDROBE",							-- 0xF0F41710
-	"HUD_CTX_IN_CAMP_WITH_SUPPLIES",						-- 0xC7569E12
-	"HUD_CTX_IN_CAMP",								-- 0x9F8612C6
-	"HUD_CTX_IN_CATALOGUE_SHOP_MENU",						-- 0x6C34EBE5
-	"HUD_CTX_IN_COMBAT_RESTRICTED_SHOP",						-- 0x6AC32FE2
-	"HUD_CTX_IN_FAST_TRAVEL_MENU",							-- 0xBB47198C
-	"HUD_CTX_IN_FISHING_MODE",							-- 0x06000911
-	"HUD_CTX_IN_GUARMA_AND_BROKE",							-- 0x3CFBD871
-	"HUD_CTX_IN_LOBBY",								-- 0x1CB7181F
-	"HUD_CTX_IN_MINIGAME_POKER_INTRO",						-- 0x727F2897
-	"HUD_CTX_IN_MINIGAME_POKER_OUTRO",						-- 0x85CF6FB0
-	"HUD_CTX_IN_MINIGAME_WITH_MP_GAME_UPDATES",					-- 0xEC1BBE94
-	"HUD_CTX_IN_MINIGAME",								-- 0x1639CD7B
-	"HUD_CTX_IN_MISSION_CUTSCENE",							-- 0x9BE7CD1D
-	"HUD_CTX_IN_MP_GAME_MODE",							-- 0x502722F2
-	"HUD_CTX_IN_MP_TUTORIAL_CUTSCENE",						-- 0xEA3A7E58
-	"HUD_CTX_IN_PHOTO_MODE",							-- 0xAC428E61
-	"HUD_CTX_IN_PHOTO_STUDIO",							-- 0xE2A1A218
-	"HUD_CTX_IN_PLAYER_CAMP",							-- 0x77DFED42
-	"HUD_CTX_IN_QUICK_TIME_EVENT",							-- 0xE6B485B4
-	"HUD_CTX_IN_RESPAWN",								-- 0xFC83EE25
-	"HUD_CTX_IN_SHOP",								-- 0xAFAF9BE1
-	"HUD_CTX_IN_STABLES",								-- 0x1A2B3041
-	"HUD_CTX_IN_TOWN",								-- 0x6D4FF8E7
-	"HUD_CTX_IN_VERSUS_CUTSCENE",							-- 0x3BCCFB49
-	"HUD_CTX_INFINITE_AMMO",							-- 0x3F129E06
-	"HUD_CTX_INFO_CARD",								-- 0xC6015EAF
-	"HUD_CTX_INPUT_REVEAL_HUD",							-- 0xFBE3143F
-	"HUD_CTX_INSPECT_ITEM",								-- 0x91DFD454
-	"HUD_CTX_INVALID",								-- 0x05891C49
-	"HUD_CTX_ITEM_CONSUMPTION_DEADEYE_CORE",					-- 0x59C84474
-	"HUD_CTX_ITEM_CONSUMPTION_DEADEYE",						-- 0xE7FB156F
-	"HUD_CTX_ITEM_CONSUMPTION_HEALTH_CORE",						-- 0x7129F41B
-	"HUD_CTX_ITEM_CONSUMPTION_HEALTH",						-- 0xBC4D0E72
-	"HUD_CTX_ITEM_CONSUMPTION_HORSE_HEALTH_CORE",					-- 0x1A2F32CC
-	"HUD_CTX_ITEM_CONSUMPTION_HORSE_HEALTH",					-- 0x4C5BE7D8
-	"HUD_CTX_ITEM_CONSUMPTION_HORSE_STAMINA_CORE",					-- 0x390A4E38
-	"HUD_CTX_ITEM_CONSUMPTION_HORSE_STAMINA",					-- 0x53B01660
-	"HUD_CTX_ITEM_CONSUMPTION_STAMINA_CORE",					-- 0x1268EBC5
-	"HUD_CTX_ITEM_CONSUMPTION_STAMINA",						-- 0x8452FC9C
-	"HUD_CTX_LOBBY_TEAM_SELECT",							-- 0x60B1D7ED
-	"HUD_CTX_MAYOR2_CUTSCENE_OBJECTIVES",						-- 0x32E36756
-	"HUD_CTX_MINIGAME_SHOOTING",							-- 0xB32DA298
-	"HUD_CTX_MISSION_CONTROLLER_CUTSCENE",						-- 0x23AB544C
-	"HUD_CTX_MISSION_CONTROLLER_INTRO",						-- 0xC4CC008A
-	"HUD_CTX_MISSION_CONTROLLER_OUTRO",						-- 0x0410B582
-	"HUD_CTX_MISSION_CONTROLLER",							-- 0x292E5336
-	"HUD_CTX_MISSION_CREATOR",							-- 0x72A6F36B
-	"HUD_CTX_MISSION_CUTSCENE_WITH_RADAR",						-- 0x68E2F9FE
-	"HUD_CTX_MONEY_ANIMATION_PLAYING",						-- 0x8D7D726A
-	"HUD_CTX_MP_BOUNTY_JAILTIME",							-- 0xFD205FD3
-	"HUD_CTX_MP_COLLECTOR_SALESWOMAN",						-- 0x4554173F
-	"HUD_CTX_MP_COOP_MISSION_POST_COMPLETION_AWARD_FLOW",				-- 0x19DE43AA
-	"HUD_CTX_MP_COOP_MISSION_POST_COMPLETION_AWARD_FLOWW",				-- 0xCC49F1AF
-	"HUD_CTX_MP_COOP_MISSION_POST_COMPLETION_PRE_AWARD_FLOW",			-- 0x0F1ADCF2
-	"HUD_CTX_MP_IN_ROLE_CUTSCENE",							-- 0xB15DD8E7
-	"HUD_CTX_MP_INSTANCED_HUD",							-- 0x20048FCF
-	"HUD_CTX_MP_INSTANCED_TOP_RIGHT_HUD",						-- 0x96E17205
-	"HUD_CTX_MP_LEADERBOARD_MINI",							-- 0x022DAAAA
-	"HUD_CTX_MP_MATCHMAKING_TRANSITION",						-- 0x07AAA30E
-	"HUD_CTX_MP_MINIGAME_SHOW_PLAYER_CASH",						-- 0x77665B04
-	"HUD_CTX_MP_MOONSHINE_BUSINESS",						-- 0x2136CA63
-	"HUD_CTX_MP_NATURALIST_ANIMAL_MODE",						-- 0x3871E8F9
-	"HUD_CTX_MP_OUT_OF_AREA_BOUNDS",						-- 0x8162B55C
-	"HUD_CTX_MP_OUTLAW_MISSIONS_MENU",						-- 0xFE3DA470
-	"HUD_CTX_MP_PLAYSTYLE_ICON_TRANSITION",						-- 0x91AB55B6
-	"HUD_CTX_MP_RACES",								-- 0xA98AC78D
-	"HUD_CTX_MP_SHOW_HUD_ABILITY_CARD_INDICATOR",					-- 0x5B6798A8
-	"HUD_CTX_MP_SPECTATING",							-- 0xE6E65A0D
-	"HUD_CTX_MP_STEW_POT_PROXIMITY",						-- 0xEA44E97E
-	"HUD_CTX_MP_TRADER",								-- 0xD15C1751
-	"HUD_CTX_MP_UGC_PLAYER_OUTRO",							-- 0xFB8AFC35
-	"HUD_CTX_NO_ALIVE_PLAYER_HORSE",						-- 0xE51AA567
-	"HUD_CTX_NON_COMBAT_MISSION",							-- 0xB58A0FF5
-	"HUD_CTX_OUTDOOR_SHOP",								-- 0x54C36872
-	"HUD_CTX_PLAYER_CAMERA_MODE",							-- 0x392F9A27
-	"HUD_CTX_PLAYER_CAMERA_REQUIRES_HUD",						-- 0x525C749F
-	"HUD_CTX_PLAYER_MENU_CAMP_MAINTENANCE",						-- 0xE0CD605F
-	"HUD_CTX_PLAYER_WITHOUT_SATCHEL",						-- 0x82721491
-	"HUD_CTX_POSSE_CREATE",								-- 0xB407BF27
-	"HUD_CTX_PROMPT_MONEY",								-- 0x9808A869
-	"HUD_CTX_RESTING_BY_FIRE",							-- 0xC476227E
-	"HUD_CTX_ROBBERY_ACTION",							-- 0xB1636C00
-	"HUD_CTX_SCRIPT_CME_CUTSCENE",							-- 0x99FCE03B
-	"HUD_CTX_SCRIPTED_IN_GAME_CUTSCENE",						-- 0x4F5FF206
-	"HUD_CTX_SCRIPTED_PLAYER_CONTROL_DISABLED",					-- 0x2B331B6E
-	"HUD_CTX_SHARP_SHOOTER_EVENT",							-- 0xFC0F918A
-	"HUD_CTX_SHOP_OBJECTIVE",							-- 0x21559C0D
-	"HUD_CTX_SHOW_MP_DEATH_SCREEN",							-- 0xEB55A95E
-	"HUD_CTX_SHOWDOWN_OUTRO",							-- 0x3B945AA6
-	"HUD_CTX_SKINNING_PROCESS",							-- 0x7B14E96E
-	"HUD_CTX_SLEEPING",								-- 0x29C7D336
-	"HUD_CTX_SP_INTRO_HORSE_ITEMS_RESTRICTED",					-- 0x17BA2997
-	"HUD_CTX_TITHING_NOGANG_CASH",							-- 0x19193F29
-	"HUD_CTX_TITHING",								-- 0x638E718A
-	"HUD_CTX_TRANSLATE_OVERLAY",							-- 0x16D28E19
-	"HUD_CTX_WATCHING_A_SHOW",							-- 0x6339DDEF
+local hud_contexts = {
+    "HUD_CTX_AMBIENT_SPECTATOR_VIEW",                         -- Hex: 0x7C2CFF26, Dec: 2083323686
+    "HUD_CTX_CHARACTER_CREATOR",                              -- Hex: 0x6A16C358, Dec: 1779876696
+    "HUD_CTX_CODE_TOOLS",                                     -- Hex: 0x15E17C71, Dec: 367098993
+    "HUD_CTX_CRAFTING_SEQUENCE",                              -- Hex: 0xE3FEFB3D, Dec: -469828803
+    "HUD_CTX_FADED_GAMEPLAY",                                 -- Hex: 0x6CD87394, Dec: 1826124692
+    "HUD_CTX_FEUD1_FISHING",                                  -- Hex: 0x54C5126F, Dec: 1422201455
+    "HUD_CTX_FIREFIGHT_CUTSCENE",                             -- Hex: 0x675A0CCC, Dec: 1733954764
+    "HUD_CTX_FISHING",                                        -- Hex: 0xCCC6D67D, Dec: -859384195
+    "HUD_CTX_GOLD_CURRENCY_CHANGE",                           -- Hex: 0x7BD554C2, Dec: 2077578434
+    "HUD_CTX_HACK_RADAR_FORCE_HIDE",                          -- Hex: 0x1C43984E, Dec: 474191950
+    "HUD_CTX_HONOR_SHOW",                                     -- Hex: 0x074132EF, Dec: 121713391
+    "HUD_CTX_IN_CAMP",                                        -- Hex: 0x9F8612C6, Dec: -1618603322
+    "HUD_CTX_IN_CAMP_WARDROBE",                               -- Hex: 0xF0F41710, Dec: -252438768
+    "HUD_CTX_IN_CAMP_WITH_SUPPLIES",                          -- Hex: 0xC7569E12, Dec: -950624750
+    "HUD_CTX_IN_CATALOGUE_SHOP_MENU",                         -- Hex: 0x6C34EBE5, Dec: 1815407589
+    "HUD_CTX_IN_COMBAT_RESTRICTED_SHOP",                      -- Hex: 0x6AC32FE2, Dec: 1791176674
+    "HUD_CTX_IN_FAST_TRAVEL_MENU",                            -- Hex: 0xBB47198C, Dec: -1152968308
+    "HUD_CTX_IN_FISHING_MODE",                                -- Hex: 0x06000911, Dec: 100665617
+    "HUD_CTX_IN_GUARMA_AND_BROKE",                            -- Hex: 0x3CFBD871, Dec: 1023137905
+    "HUD_CTX_IN_LOBBY",                                       -- Hex: 0x1CB7181F, Dec: 481761311
+    "HUD_CTX_IN_MINIGAME",                                    -- Hex: 0x1639CD7B, Dec: 372886907
+    "HUD_CTX_IN_MINIGAME_POKER_INTRO",                        -- Hex: 0x727F2897, Dec: 1920936087
+    "HUD_CTX_IN_MINIGAME_POKER_OUTRO",                        -- Hex: 0x85CF6FB0, Dec: -2050003024
+    "HUD_CTX_IN_MINIGAME_WITH_MP_GAME_UPDATES",               -- Hex: 0xEC1BBE94, Dec: -333726060
+    "HUD_CTX_IN_MISSION_CUTSCENE",                            -- Hex: 0x9BE7CD1D, Dec: -1679307491
+    "HUD_CTX_IN_MP_GAME_MODE",                                -- Hex: 0x502722F2, Dec: 1344742130
+    "HUD_CTX_IN_MP_TUTORIAL_CUTSCENE",                        -- Hex: 0xEA3A7E58, Dec: -365265320
+    "HUD_CTX_IN_PHOTO_MODE",                                  -- Hex: 0xAC428E61, Dec: -1404924319
+    "HUD_CTX_IN_PHOTO_STUDIO",                                -- Hex: 0xE2A1A218, Dec: -492723688
+    "HUD_CTX_IN_PLAYER_CAMP",                                 -- Hex: 0x77DFED42, Dec: 2011163970
+    "HUD_CTX_IN_QUICK_TIME_EVENT",                            -- Hex: 0xE6B485B4, Dec: -424376908
+    "HUD_CTX_IN_RESPAWN",                                     -- Hex: 0xFC83EE25, Dec: -58462683
+    "HUD_CTX_IN_SHOP",                                        -- Hex: 0xAFAF9BE1, Dec: -1347445791
+    "HUD_CTX_IN_STABLES",                                     -- Hex: 0x1A2B3041, Dec: 439038017
+    "HUD_CTX_IN_TOWN",                                        -- Hex: 0x6D4FF8E7, Dec: 1833957607
+    "HUD_CTX_IN_VERSUS_CUTSCENE",                             -- Hex: 0x3BCCFB49, Dec: 1003289417
+    "HUD_CTX_INFINITE_AMMO",                                  -- Hex: 0x3F129E06, Dec: 1058184710
+    "HUD_CTX_INFO_CARD",                                      -- Hex: 0xC6015EAF, Dec: -972988753
+    "HUD_CTX_INPUT_REVEAL_HUD",                               -- Hex: 0xFBE3143F, Dec: -69004225
+    "HUD_CTX_INSPECT_ITEM",                                   -- Hex: 0x91DFD454, Dec: -1847602092
+    "HUD_CTX_ITEM_CONSUMPTION_DEADEYE",                       -- Hex: 0xE7FB156F, Dec: -402975377
+    "HUD_CTX_ITEM_CONSUMPTION_DEADEYE_CORE",                  -- Hex: 0x59C84474, Dec: 1506296948
+    "HUD_CTX_ITEM_CONSUMPTION_HEALTH",                        -- Hex: 0xBC4D0E72, Dec: -1135800718
+    "HUD_CTX_ITEM_CONSUMPTION_HEALTH_CORE",                   -- Hex: 0x7129F41B, Dec: 1898574875
+    "HUD_CTX_ITEM_CONSUMPTION_HORSE_HEALTH",                  -- Hex: 0x4C5BE7D8, Dec: 1281091544
+    "HUD_CTX_ITEM_CONSUMPTION_HORSE_HEALTH_CORE",             -- Hex: 0x1A2F32CC, Dec: 439300812
+    "HUD_CTX_ITEM_CONSUMPTION_HORSE_STAMINA",                 -- Hex: 0x53B01660, Dec: 1404048992
+    "HUD_CTX_ITEM_CONSUMPTION_HORSE_STAMINA_CORE",            -- Hex: 0x390A4E38, Dec: 956976696
+    "HUD_CTX_ITEM_CONSUMPTION_STAMINA",                       -- Hex: 0x8452FC9C, Dec: -2074936164
+    "HUD_CTX_ITEM_CONSUMPTION_STAMINA_CORE",                  -- Hex: 0x1268EBC5, Dec: 308865989
+    "HUD_CTX_LOBBY_TEAM_SELECT",                              -- Hex: 0x60B1D7ED, Dec: 1622267885
+    "HUD_CTX_MAYOR2_CUTSCENE_OBJECTIVES",                     -- Hex: 0x32E36756, Dec: 853763926
+    "HUD_CTX_MINIGAME_SHOOTING",                              -- Hex: 0xB32DA298, Dec: -1288854888
+    "HUD_CTX_MISSION_CONTROLLER",                             -- Hex: 0x292E5336, Dec: 690901814
+    "HUD_CTX_MISSION_CONTROLLER_CUTSCENE",                    -- Hex: 0x23AB544C, Dec: 598430796
+    "HUD_CTX_MISSION_CONTROLLER_INTRO",                       -- Hex: 0xC4CC008A, Dec: -993263478
+    "HUD_CTX_MISSION_CONTROLLER_OUTRO",                       -- Hex: 0x0410B582, Dec: 68203906
+    "HUD_CTX_MISSION_CREATOR",                                -- Hex: 0x72A6F36B, Dec: 1923543915
+    "HUD_CTX_MISSION_CUTSCENE_WITH_RADAR",                    -- Hex: 0x68E2F9FE, Dec: 1759705598
+    "HUD_CTX_MONEY_ANIMATION_PLAYING",                        -- Hex: 0x8D7D726A, Dec: -1921158550
+    "HUD_CTX_MP_BOUNTY_JAILTIME",                             -- Hex: 0xFD205FD3, Dec: -48209965
+    "HUD_CTX_MP_COLLECTOR_SALESWOMAN",                        -- Hex: 0x4554173F, Dec: 1163138879
+    "HUD_CTX_MP_COOP_MISSION_POST_COMPLETION_AWARD_FLOW",     -- Hex: 0x19DE43AA, Dec: 433996714
+    "HUD_CTX_MP_COOP_MISSION_POST_COMPLETION_PRE_AWARD_FLOW", -- Hex: 0x0F1ADCF2, Dec: 253418738
+    "HUD_CTX_MP_IN_ROLE_CUTSCENE",                            -- Hex: 0xB15DD8E7, Dec: -1319249689
+    "HUD_CTX_MP_INSTANCED_HUD",                               -- Hex: 0x20048FCF, Dec: 537169871
+    "HUD_CTX_MP_INSTANCED_TOP_RIGHT_HUD",                     -- Hex: 0x96E17205, Dec: -1763610107
+    "HUD_CTX_MP_LEADERBOARD_MINI",                            -- Hex: 0x022DAAAA, Dec: 36547242
+    "HUD_CTX_MP_MATCHMAKING_TRANSITION",                      -- Hex: 0x07AAA30E, Dec: 128623374
+    "HUD_CTX_MP_MINIGAME_SHOW_PLAYER_CASH",                   -- Hex: 0x77665B04, Dec: 2003196676
+    "HUD_CTX_MP_MOONSHINE_BUSINESS",                          -- Hex: 0x2136CA63, Dec: 557238883
+    "HUD_CTX_MP_NATURALIST_ANIMAL_MODE",                      -- Hex: 0x3871E8F9, Dec: 946989305
+    "HUD_CTX_MP_OUT_OF_AREA_BOUNDS",                          -- Hex: 0x8162B55C, Dec: -2124237476
+    "HUD_CTX_MP_OUTLAW_MISSIONS_MENU",                        -- Hex: 0xFE3DA470, Dec: -29514640
+    "HUD_CTX_MP_PLAYSTYLE_ICON_TRANSITION",                   -- Hex: 0x91AB55B6, Dec: -1851042378
+    "HUD_CTX_MP_RACES",                                       -- Hex: 0xA98AC78D, Dec: -1450522739
+    "HUD_CTX_MP_SHOW_HUD_ABILITY_CARD_INDICATOR",             -- Hex: 0x5B6798A8, Dec: 1533515944
+    "HUD_CTX_MP_SPECTATING",                                  -- Hex: 0xE6E65A0D, Dec: -421111283
+    "HUD_CTX_MP_STEW_POT_PROXIMITY",                          -- Hex: 0xEA44E97E, Dec: -364582530
+    "HUD_CTX_MP_TRADER",                                      -- Hex: 0xD15C1751, Dec: -782493871
+    "HUD_CTX_MP_UGC_PLAYER_OUTRO",                            -- Hex: 0xFB8AFC35, Dec: -74777547
+    "HUD_CTX_NO_ALIVE_PLAYER_HORSE",                          -- Hex: 0xE51AA567, Dec: -451238553
+    "HUD_CTX_NON_COMBAT_MISSION",                             -- Hex: 0xB58A0FF5, Dec: -1249243147
+    "HUD_CTX_OUTDOOR_SHOP",                                   -- Hex: 0x54C36872, Dec: 1422092402
+    "HUD_CTX_PLAYER_CAMERA_MODE",                             -- Hex: 0x392F9A27, Dec: 959420967
+    "HUD_CTX_PLAYER_CAMERA_REQUIRES_HUD",                     -- Hex: 0x525C749F, Dec: 1381790879
+    "HUD_CTX_PLAYER_MENU_CAMP_MAINTENANCE",                   -- Hex: 0xE0CD605F, Dec: -523411361
+    "HUD_CTX_PLAYER_WITHOUT_SATCHEL",                         -- Hex: 0x82721491, Dec: -2106452847
+    "HUD_CTX_POSSE_CREATE",                                   -- Hex: 0xB407BF27, Dec: -1274560729
+    "HUD_CTX_PROMPT_MONEY",                                   -- Hex: 0x9808A869, Dec: -1744263063
+    "HUD_CTX_RESTING_BY_FIRE",                                -- Hex: 0xC476227E, Dec: -998890882
+    "HUD_CTX_ROBBERY_ACTION",                                 -- Hex: 0xB1636C00, Dec: -1318884352
+    "HUD_CTX_SCRIPT_CME_CUTSCENE",                            -- Hex: 0x99FCE03B, Dec: -1711480773
+    "HUD_CTX_SCRIPTED_IN_GAME_CUTSCENE",                      -- Hex: 0x4F5FF206, Dec: 1331687942
+    "HUD_CTX_SCRIPTED_PLAYER_CONTROL_DISABLED",               -- Hex: 0x2B331B6E, Dec: 724769646
+    "HUD_CTX_SHARP_SHOOTER_EVENT",                            -- Hex: 0xFC0F918A, Dec: -66088566
+    "HUD_CTX_SHOP_OBJECTIVE",                                 -- Hex: 0x21559C0D, Dec: 559258637
+    "HUD_CTX_SHOW_MP_DEATH_SCREEN",                           -- Hex: 0xEB55A95E, Dec: -346707618
+    "HUD_CTX_SHOWDOWN_OUTRO",                                 -- Hex: 0x3B945AA6, Dec: 999578278
+    "HUD_CTX_SKINNING_PROCESS",                               -- Hex: 0x7B14E96E, Dec: 2064968046
+    "HUD_CTX_SLEEPING",                                       -- Hex: 0x29C7D336, Dec: 700961590
+    "HUD_CTX_SP_INTRO_HORSE_ITEMS_RESTRICTED",                -- Hex: 0x17BA2997, Dec: 398076311
+    "HUD_CTX_TITHING",                                        -- Hex: 0x638E718A, Dec: 1670279562
+    "HUD_CTX_TITHING_NOGANG_CASH",                            -- Hex: 0x19193F29, Dec: 421084969
+    "HUD_CTX_TRANSLATE_OVERLAY",                              -- Hex: 0x16D28E19, Dec: 382897689
+    "HUD_CTX_WATCHING_A_SHOW",                                -- Hex: 0x6339DDEF, Dec: 1664736751
+    "HUD_CTX_INVALID",                                        -- Hex: 0x05891C49, Dec: 92871753
 }


### PR DESCRIPTION
Although I would rather remove the file completely, it does serve another purpose (listing hex and now decimal values) and is linked to in several native documentations, so I decided to clean it up, add decimals and a link to what I would consider to be the main documentation for these.